### PR TITLE
Feat: GET /tokens when user reload window

### DIFF
--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -11,6 +11,7 @@ const {
   changePasswordService,
   adminLogoutService,
   issueTokenService,
+  issueTokenAgainService,
 } = require('../services/admin.service');
 
 const getAdminInfoControl = async (req, _res) => {
@@ -90,10 +91,30 @@ const issueTokenControl = async (req, res) => {
   };
 };
 
+const issueTokenAgainControl = async (req, res) => {
+  res.clearCookie('accesstoken').clearCookie('refreshtoken');
+  const { id, name } = req;
+  if (!id || !name) {
+    throw new UnauthorizedException('Login again.');
+  }
+  const { accesstoken, refreshtoken } = await issueTokenAgainService(id, name);
+  res
+    .cookie('accesstoken', accesstoken, { httpOnly: true })
+    .cookie('refreshtoken', refreshtoken, { httpOnly: true });
+  return {
+    message: 'Issue again success.',
+    data: {
+      accesstoken,
+      refreshtoken,
+    },
+  };
+};
+
 module.exports = {
   getAdminInfoControl,
   adminLoginControl,
   adminLogoutControl,
   changePasswordControl,
   issueTokenControl,
+  issueTokenAgainControl,
 };

--- a/src/routes/admin.route.js
+++ b/src/routes/admin.route.js
@@ -5,6 +5,7 @@ const {
   adminLogoutControl,
   changePasswordControl,
   issueTokenControl,
+  issueTokenAgainControl,
 } = require('../controllers/admin.controller');
 const { verifyToken } = require('../lib/auth-middleware');
 const wrapper = require('../lib/request-handler');
@@ -14,5 +15,6 @@ router.post('/login', wrapper(adminLoginControl));
 router.post('/logout', verifyToken, wrapper(adminLogoutControl));
 router.put('/password', verifyToken, wrapper(changePasswordControl));
 router.get('/accesstoken', wrapper(issueTokenControl));
+router.get('/tokens', verifyToken, wrapper(issueTokenAgainControl));
 
 module.exports = router;

--- a/src/services/admin.service.js
+++ b/src/services/admin.service.js
@@ -1,5 +1,8 @@
 const bcrypt = require('bcrypt');
-const { BadRequestException } = require('../common/exceptions');
+const {
+  BadRequestException,
+  UnauthorizedException,
+} = require('../common/exceptions');
 const { sign, verify } = require('../lib/jwt');
 const AdminModel = require('../models/admin.model');
 
@@ -94,10 +97,33 @@ const issueTokenService = async (accesstoken, refreshtoken) => {
   };
 };
 
+const issueTokenAgainService = async (id, name) => {
+  const result = await AdminModel.findOne({ id }).exec();
+  if (!result) {
+    throw new UnauthorizedException('Login again.');
+  }
+  const accesstoken = sign({ id, name }, undefined, 0);
+  const refreshtoken = sign({ id, name }, undefined, 1);
+  const index = result.refreshtokens.findIndex(
+    (element) => element.name === name
+  );
+  if (index >= 0) {
+    result.refreshtokens[index].refreshtoken = refreshtoken;
+  } else {
+    result.refreshtokens.push({ name, refreshtoken });
+  }
+  await result.save();
+  return {
+    accesstoken,
+    refreshtoken,
+  };
+};
+
 module.exports = {
   getAdminInfoService,
   adminLoginService,
   adminLogoutService,
   changePasswordService,
   issueTokenService,
+  issueTokenAgainService,
 };


### PR DESCRIPTION
사용자가 화면을 새로고침 했을 때, 클라이언트 단에서 갖고 있던 refresh token과 access token이 사라지는데, 쿠키에는 남아있으므로 GET /tokens API를 통해 다시 새로운 access token과 refresh token을 발급 받도록 해야한다.